### PR TITLE
[RFC] Allow a trailing comma in function and method calls

### DIFF
--- a/Zend/tests/function_arguments/call_with_leading_comma_error.phpt
+++ b/Zend/tests/function_arguments/call_with_leading_comma_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Leading commas in function calls is not allowed
+--FILE--
+<?php
+foo(,$foo);
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',' in %s on line %d

--- a/Zend/tests/function_arguments/call_with_multi_inner_comma_error.phpt
+++ b/Zend/tests/function_arguments/call_with_multi_inner_comma_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Multiple inner commas in function calls is not allowed
+--FILE--
+<?php
+foo($foo,,$bar);
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting ')' in %s on line %d

--- a/Zend/tests/function_arguments/call_with_multi_trailing_comma_error.phpt
+++ b/Zend/tests/function_arguments/call_with_multi_trailing_comma_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Multiple trailing commas in function calls is not allowed
+--FILE--
+<?php
+foo($foo,,);
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',', expecting ')' in %s on line %d

--- a/Zend/tests/function_arguments/call_with_only_comma_error.phpt
+++ b/Zend/tests/function_arguments/call_with_only_comma_error.phpt
@@ -1,0 +1,8 @@
+--TEST--
+Single comma in function calls is not allowed
+--FILE--
+<?php
+foo(,);
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected ',' in %s on line %d

--- a/Zend/tests/function_arguments/call_with_trailing_comma_basic.phpt
+++ b/Zend/tests/function_arguments/call_with_trailing_comma_basic.phpt
@@ -1,0 +1,97 @@
+--TEST--
+Allow trailing commas in function and method calls
+--FILE--
+<?php
+function foo(...$args) {
+  echo __FUNCTION__ . "\n";
+  var_dump($args);
+}
+foo(
+  'function',
+  'bar',
+);
+
+class Foo
+{
+  public function __construct(...$args) {
+    echo __FUNCTION__ . "\n";
+    var_dump($args);
+  }
+  
+  public function bar(...$args) {
+    echo __FUNCTION__ . "\n";
+    var_dump($args);
+  }
+  
+  public function __invoke(...$args) {
+    echo __FUNCTION__ . "\n";
+    var_dump($args);
+  }
+}
+
+$foo = new Foo(
+  'constructor',
+  'bar',
+);
+
+$foo->bar(
+  'method',
+  'bar',
+);
+
+$foo(
+  'invoke',
+  'bar',
+);
+
+$bar = function(...$args) {
+  echo __FUNCTION__ . "\n";
+  var_dump($args);
+};
+
+$bar(
+  'closure',
+  'bar',
+);
+
+# Make sure to hit the "not really a function" language constructs
+unset($foo, $bar,);
+var_dump(isset($foo, $bar,));
+?>
+--EXPECT--
+foo
+array(2) {
+  [0]=>
+  string(8) "function"
+  [1]=>
+  string(3) "bar"
+}
+__construct
+array(2) {
+  [0]=>
+  string(11) "constructor"
+  [1]=>
+  string(3) "bar"
+}
+bar
+array(2) {
+  [0]=>
+  string(6) "method"
+  [1]=>
+  string(3) "bar"
+}
+__invoke
+array(2) {
+  [0]=>
+  string(6) "invoke"
+  [1]=>
+  string(3) "bar"
+}
+{closure}
+array(2) {
+  [0]=>
+  string(7) "closure"
+  [1]=>
+  string(3) "bar"
+}
+bool(false)

--- a/Zend/zend_language_parser.y
+++ b/Zend/zend_language_parser.y
@@ -439,7 +439,7 @@ statement:
 	|	T_ECHO echo_expr_list ';'		{ $$ = $2; }
 	|	T_INLINE_HTML { $$ = zend_ast_create(ZEND_AST_ECHO, $1); }
 	|	expr ';' { $$ = $1; }
-	|	T_UNSET '(' unset_variables ')' ';' { $$ = $3; }
+	|	T_UNSET '(' unset_variables possible_comma ')' ';' { $$ = $3; }
 	|	T_FOREACH '(' expr T_AS foreach_variable ')' foreach_statement
 			{ $$ = zend_ast_create(ZEND_AST_FOREACH, $3, $5, NULL, $7); }
 	|	T_FOREACH '(' expr T_AS foreach_variable T_DOUBLE_ARROW foreach_variable ')'
@@ -670,7 +670,7 @@ return_type:
 
 argument_list:
 		'(' ')'	{ $$ = zend_ast_create_list(0, ZEND_AST_ARG_LIST); }
-	|	'(' non_empty_argument_list ')' { $$ = $2; }
+	|	'(' non_empty_argument_list possible_comma ')' { $$ = $2; }
 ;
 
 non_empty_argument_list:
@@ -1260,7 +1260,7 @@ encaps_var_offset:
 
 
 internal_functions_in_yacc:
-		T_ISSET '(' isset_variables ')' { $$ = $3; }
+		T_ISSET '(' isset_variables possible_comma ')' { $$ = $3; }
 	|	T_EMPTY '(' expr ')' { $$ = zend_ast_create(ZEND_AST_EMPTY, $3); }
 	|	T_INCLUDE expr
 			{ $$ = zend_ast_create_ex(ZEND_AST_INCLUDE_OR_EVAL, ZEND_INCLUDE, $2); }


### PR DESCRIPTION
This is the implementation for the [RFC to allow a trailing comma in function/method calls](https://wiki.php.net/rfc/trailing-comma-function-calls) which targets PHP 7.3. The RFC passed on *2017-11-04 18:30 UTC* with a *30 to 10* vote.

![trailing-comma-all-the-things](https://user-images.githubusercontent.com/578780/32408857-0a2bff16-c16e-11e7-87cb-d8d1dc11540f.jpg)