### PR TITLE
Rename zend_instrument -> zend_instrument_fcall

### DIFF
--- a/Zend/zend_closures.c
+++ b/Zend/zend_closures.c
@@ -310,8 +310,8 @@ static int zend_create_closure_from_callable(zval *return_value, zval *callable,
 		call.scope = mptr->common.scope;
 
 		// TODO: Is this correct???
-		static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call.instrument_cache, (zend_instrument_cache **) &dummy_handlers);
+		static const zend_instrument_fcall_cache *dummy_handlers = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handlers);
 
 		zend_free_trampoline(mptr);
 		mptr = (zend_function *) &call;
@@ -401,8 +401,8 @@ ZEND_API zend_function *zend_get_closure_invoke_method(zend_object *object) /* {
 	invoke->internal_function.function_name = ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE);
 
 	// TODO: Is this correct???
-	static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-	ZEND_MAP_PTR_INIT(invoke->internal_function.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+	static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+	ZEND_MAP_PTR_INIT(invoke->internal_function.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	return invoke;
 }
 /* }}} */

--- a/Zend/zend_compile.h
+++ b/Zend/zend_compile.h
@@ -403,7 +403,7 @@ struct _zend_op_array {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_arg_info *arg_info;
-	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+	ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	/* END of common elements */
 
 	int cache_size;     /* number of run_time_cache_slots * sizeof(void*) */
@@ -453,7 +453,7 @@ typedef struct _zend_internal_function {
 	uint32_t num_args;
 	uint32_t required_num_args;
 	zend_internal_arg_info *arg_info;
-	ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+	ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	/* END of common elements */
 
 	zif_handler handler;
@@ -477,7 +477,7 @@ union _zend_function {
 		uint32_t num_args;
 		uint32_t required_num_args;
 		zend_arg_info *arg_info;  /* index -1 represents the return value info, if any */
-		ZEND_MAP_PTR_DEF(struct zend_instrument_cache *, instrument_cache);
+		ZEND_MAP_PTR_DEF(struct zend_instrument_fcall_cache *, instrument_cache);
 	} common;
 
 	zend_op_array op_array;

--- a/Zend/zend_execute.c
+++ b/Zend/zend_execute.c
@@ -3503,7 +3503,7 @@ ZEND_API zend_function * ZEND_FASTCALL zend_fetch_function(zend_string *name) /*
 			init_func_run_time_cache_i(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		return fbc;
 	}
@@ -3521,7 +3521,7 @@ ZEND_API zend_function * ZEND_FASTCALL zend_fetch_function_str(const char *name,
 			init_func_run_time_cache_i(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		return fbc;
 	}
@@ -3559,7 +3559,7 @@ static zend_always_inline void i_init_code_execute_data(zend_execute_data *execu
 		ZEND_MAP_PTR_INIT(op_array->instrument_cache,
 			zend_arena_alloc(&CG(arena), sizeof(void*)));
 		ZEND_MAP_PTR_SET(op_array->instrument_cache, NULL);
-		zend_instrument_install_handlers((zend_function *) op_array);
+		zend_instrument_fcall_install((zend_function *)op_array);
 	}
 	EX(run_time_cache) = RUN_TIME_CACHE(op_array);
 
@@ -3586,7 +3586,7 @@ ZEND_API void zend_init_func_execute_data(zend_execute_data *ex, zend_op_array *
 		init_func_run_time_cache(op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(op_array->instrument_cache))) {
-		zend_instrument_install_handlers((zend_function *) op_array);
+		zend_instrument_fcall_install((zend_function *)op_array);
 	}
 	i_init_func_execute_data(op_array, return_value, 1 EXECUTE_DATA_CC);
 
@@ -3940,7 +3940,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	} else {
 		if (ZSTR_VAL(function)[0] == '\\') {
@@ -3961,7 +3961,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_string(zend_s
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		called_scope = NULL;
 	}
@@ -4008,7 +4008,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_object(zend_o
 		init_func_run_time_cache(&fbc->op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-		zend_instrument_install_handlers(fbc);
+		zend_instrument_fcall_install(fbc);
 	}
 
 	return zend_vm_stack_push_call_frame(call_info,
@@ -4096,7 +4096,7 @@ static zend_never_inline zend_execute_data *zend_init_dynamic_call_array(zend_ar
 		init_func_run_time_cache(&fbc->op_array);
 	}
 	if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-		zend_instrument_install_handlers(fbc);
+		zend_instrument_fcall_install(fbc);
 	}
 
 	return zend_vm_stack_push_call_frame(call_info,

--- a/Zend/zend_execute.h
+++ b/Zend/zend_execute.h
@@ -41,14 +41,13 @@ ZEND_API void zend_init_code_execute_data(zend_execute_data *execute_data, zend_
 ZEND_API void zend_execute(zend_op_array *op_array, zval *return_value);
 ZEND_API void execute_ex(zend_execute_data *execute_data);
 
-ZEND_API inline void execute_internal(zend_execute_data *execute_data, zval *return_value)
-{
-	zend_instrument_cache *cache = (zend_instrument_cache *)
+ZEND_API inline void execute_internal(zend_execute_data *execute_data, zval *return_value) {
+	zend_instrument_fcall_cache *cache = (zend_instrument_fcall_cache *)
 		ZEND_MAP_PTR_GET(execute_data->func->common.instrument_cache);
-	if (UNEXPECTED(cache != ZEND_NOT_INSTRUMENTED)) {
-		zend_instrument_call_begin_handlers(execute_data, cache);
+	if (UNEXPECTED(cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED)) {
+		zend_instrument_fcall_call_begin(cache, execute_data);
 		execute_data->func->internal_function.handler(execute_data, return_value);
-		zend_instrument_call_end_handlers(execute_data, cache);
+		zend_instrument_fcall_call_end(cache, execute_data, return_value);
 	} else {
 		execute_data->func->internal_function.handler(execute_data, return_value);
 	}

--- a/Zend/zend_execute_API.c
+++ b/Zend/zend_execute_API.c
@@ -799,9 +799,9 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		const zend_op *current_opline_before_exception = EG(opline_before_exception);
 
 		zend_init_func_execute_data(call, &func->op_array, fci->retval);
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 		zend_execute_ex(call);
 		EG(opline_before_exception) = current_opline_before_exception;
@@ -815,7 +815,7 @@ int zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /
 		ZEND_ASSERT(func->type == ZEND_INTERNAL_FUNCTION);
 
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 
 		ZVAL_NULL(fci->retval);

--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -1204,7 +1204,8 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	 * The low bit must be zero, to not be interpreted as a MAP_PTR offset.
 	 */
 	static const void *dummy = (void*)(intptr_t)2;
-	static const zend_instrument_cache *dummy_handlers = ZEND_NOT_INSTRUMENTED;
+	static const zend_instrument_fcall_cache *dummy_handlers =
+		ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
 
 	ZEND_ASSERT(fbc);
 
@@ -1224,7 +1225,7 @@ ZEND_API zend_function *zend_get_call_trampoline_func(zend_class_entry *ce, zend
 	}
 	func->opcodes = &EG(call_trampoline_op);
 	ZEND_MAP_PTR_INIT(func->run_time_cache, (void***)&dummy);
-	ZEND_MAP_PTR_INIT(func->instrument_cache, (zend_instrument_cache **) &dummy_handlers);
+	ZEND_MAP_PTR_INIT(func->instrument_cache, (zend_instrument_fcall_cache **) &dummy_handlers);
 	func->scope = fbc->common.scope;
 	/* reserve space for arguments, local and temporary variables */
 	func->T = (fbc->type == ZEND_USER_FUNCTION)? MAX(fbc->op_array.last_var + fbc->op_array.T, 2) : 2;

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -3469,7 +3469,7 @@ ZEND_VM_HOT_OBJ_HANDLER(112, ZEND_INIT_METHOD_CALL, CONST|TMPVAR|UNUSED|THIS|CV,
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -3596,7 +3596,7 @@ ZEND_VM_HANDLER(113, ZEND_INIT_STATIC_METHOD_CALL, UNUSED|CLASS_FETCH|CONST|VAR,
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (OP2_TYPE != IS_CONST) {
 			FREE_OP2();
@@ -3615,7 +3615,7 @@ ZEND_VM_HANDLER(113, ZEND_INIT_STATIC_METHOD_CALL, UNUSED|CLASS_FETCH|CONST|VAR,
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -3668,7 +3668,7 @@ ZEND_VM_HOT_HANDLER(59, ZEND_INIT_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3783,7 +3783,7 @@ ZEND_VM_HANDLER(118, ZEND_INIT_USER_CALL, CONST, CONST|TMPVAR|CV, NUM)
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -3823,7 +3823,7 @@ ZEND_VM_HOT_HANDLER(69, ZEND_INIT_NS_FCALL_BY_NAME, ANY, CONST, NUM|CACHE_SLOT)
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3856,7 +3856,7 @@ ZEND_VM_HOT_HANDLER(61, ZEND_INIT_FCALL, NUM, CONST, NUM|CACHE_SLOT)
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3940,9 +3940,10 @@ ZEND_VM_HOT_HANDLER(130, ZEND_DO_UCALL, ANY, ANY, SPEC(RETVAL))
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-	zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-	if (cache != ZEND_NOT_INSTRUMENTED) {
-		zend_instrument_call_begin_handlers(call, cache);
+	zend_instrument_fcall_cache *cache =
+		ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+	if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+		zend_instrument_fcall_call_begin(cache, call);
 	}
 
 	LOAD_OPLINE_EX();
@@ -3970,9 +3971,10 @@ ZEND_VM_HOT_HANDLER(131, ZEND_DO_FCALL_BY_NAME, ANY, ANY, SPEC(RETVAL))
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		LOAD_OPLINE_EX();
@@ -4057,9 +4059,10 @@ ZEND_VM_HOT_HANDLER(60, ZEND_DO_FCALL, ANY, ANY, SPEC(RETVAL))
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
@@ -4270,9 +4273,10 @@ ZEND_VM_INLINE_HANDLER(62, ZEND_RETURN, CONST|TMP|VAR|CV, ANY)
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -5381,14 +5385,14 @@ ZEND_VM_HANDLER(68, ZEND_NEW, UNUSED|CLASS_FETCH|CONST|VAR, UNUSED|CACHE_SLOT, N
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -7371,9 +7375,12 @@ ZEND_VM_HELPER(zend_dispatch_try_catch_finally_helper, ANY, ANY, uint32_t try_ca
 
 	if (execute_data->func) {
 		zend_function *func = execute_data->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(execute_data, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zval undef;
+			ZVAL_UNDEF(&undef);
+			zend_instrument_fcall_call_end(cache, execute_data, &undef);
 		}
 	}
 
@@ -8169,7 +8176,7 @@ ZEND_VM_HANDLER(158, ZEND_CALL_TRAMPOLINE, ANY, ANY)
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -1333,9 +1333,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-	zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-	if (cache != ZEND_NOT_INSTRUMENTED) {
-		zend_instrument_call_begin_handlers(call, cache);
+	zend_instrument_fcall_cache *cache =
+		ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+	if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+		zend_instrument_fcall_call_begin(cache, call);
 	}
 
 	LOAD_OPLINE_EX();
@@ -1362,9 +1363,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_UCALL_SPEC_RETV
 	execute_data = call;
 	i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-	zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-	if (cache != ZEND_NOT_INSTRUMENTED) {
-		zend_instrument_call_begin_handlers(call, cache);
+	zend_instrument_fcall_cache *cache =
+		ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+	if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+		zend_instrument_fcall_call_begin(cache, call);
 	}
 
 	LOAD_OPLINE_EX();
@@ -1392,9 +1394,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		LOAD_OPLINE_EX();
@@ -1479,9 +1482,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_BY_NAME_S
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		LOAD_OPLINE_EX();
@@ -1566,9 +1570,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
@@ -1669,9 +1674,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_DO_FCALL_SPEC_RETV
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 1 EXECUTE_DATA_CC);
 
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_begin_handlers(call, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(fbc->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_begin(cache, call);
 		}
 
 		if (EXPECTED(zend_execute_ex == execute_ex)) {
@@ -2557,9 +2563,12 @@ static zend_never_inline ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL zend_dispatch_try
 
 	if (execute_data->func) {
 		zend_function *func = execute_data->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(execute_data, cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zval undef;
+			ZVAL_UNDEF(&undef);
+			zend_instrument_fcall_call_end(cache, execute_data, &undef);
 		}
 	}
 
@@ -2790,7 +2799,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_CALL_TRAMPOLINE_SPEC_HANDLER(Z
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		execute_data = call;
 		i_init_func_execute_data(&fbc->op_array, ret, 0 EXECUTE_DATA_CC);
@@ -2909,7 +2918,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_FCALL_BY_NAME
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -2998,7 +3007,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_NS_FCALL_BY_N
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3031,7 +3040,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_FCALL_SPEC_CO
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		CACHE_PTR(opline->result.num, fbc);
 	}
@@ -3580,9 +3589,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CONST_
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -5744,7 +5754,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -5870,7 +5880,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -5889,7 +5899,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -5970,7 +5980,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CONS
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -7931,7 +7941,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8057,7 +8067,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -8076,7 +8086,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8158,7 +8168,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_TMPV
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -8809,7 +8819,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -8828,7 +8838,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -8973,14 +8983,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_CONST_UNUSED_HANDLER(
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -10210,7 +10220,7 @@ static ZEND_VM_COLD ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -10336,7 +10346,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -10355,7 +10365,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -10436,7 +10446,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_USER_CALL_SPEC_CONST_CV_H
 			init_func_run_time_cache(&func->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(func->common.instrument_cache))) {
-			zend_instrument_install_handlers(func);
+			zend_instrument_fcall_install(func);
 		}
 	} else {
 		zend_type_error("%s(): Argument #1 ($function) must be a valid callback, %s", Z_STRVAL_P(RT_CONSTANT(opline, opline->op1)), error);
@@ -14513,7 +14523,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -15897,7 +15907,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_T
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -17175,7 +17185,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_TMPVAR_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -17500,9 +17510,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_TMP_HA
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -19931,9 +19942,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_VAR_HA
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -22855,7 +22867,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -22874,7 +22886,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -25091,7 +25103,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -25110,7 +25122,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -26369,7 +26381,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -26388,7 +26400,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -26533,14 +26545,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_VAR_UNUSED_HANDLER(ZE
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -28633,7 +28645,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -28652,7 +28664,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_V
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -30702,7 +30714,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_S
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -30828,7 +30840,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CONST != IS_CONST) {
 
@@ -30847,7 +30859,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -32579,7 +32591,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_T
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -32705,7 +32717,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if ((IS_TMP_VAR|IS_VAR) != IS_CONST) {
 			zval_ptr_dtor_nogc(EX_VAR(opline->op2.var));
@@ -32724,7 +32736,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -33127,7 +33139,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_UNUSED != IS_CONST) {
 
@@ -33146,7 +33158,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -33291,14 +33303,14 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_NEW_SPEC_UNUSED_UNUSED_HANDLER
 		call = zend_vm_stack_push_call_frame(
 			ZEND_CALL_FUNCTION, (zend_function *) &zend_pass_function,
 			opline->extended_value, NULL);
-		static const zend_instrument_cache *dummy_handler = ZEND_NOT_INSTRUMENTED;
-		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_cache **) &dummy_handler);
+		static const zend_instrument_fcall_cache *dummy_handler = ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED;
+		ZEND_MAP_PTR_INIT(call->func->common.instrument_cache, (zend_instrument_fcall_cache **) &dummy_handler);
 	} else {
 		if (EXPECTED(constructor->type == ZEND_USER_FUNCTION) && UNEXPECTED(!RUN_TIME_CACHE(&constructor->op_array))) {
 			init_func_run_time_cache(&constructor->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(constructor->common.instrument_cache))) {
-			zend_instrument_install_handlers(constructor);
+			zend_instrument_fcall_install(constructor);
 		}
 		/* We are not handling overloaded classes right now */
 		call = zend_vm_stack_push_call_frame(
@@ -34993,7 +35005,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_UNUSED_C
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -35119,7 +35131,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 		if (IS_CV != IS_CONST) {
 
@@ -35138,7 +35150,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_STATIC_METHOD_CALL_SPEC_U
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -35941,9 +35953,10 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_RETURN_SPEC_CV_HAN
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -39860,7 +39873,7 @@ static ZEND_VM_HOT ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_S
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -43300,7 +43313,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_TMPVA
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -48185,7 +48198,7 @@ static ZEND_OPCODE_HANDLER_RET ZEND_FASTCALL ZEND_INIT_METHOD_CALL_SPEC_CV_CV_HA
 			init_func_run_time_cache(&fbc->op_array);
 		}
 		if (UNEXPECTED(!ZEND_MAP_PTR_GET(fbc->common.instrument_cache))) {
-			zend_instrument_install_handlers(fbc);
+			zend_instrument_fcall_install(fbc);
 		}
 	}
 
@@ -52525,9 +52538,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -54019,9 +54033,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -54305,9 +54320,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 
@@ -55379,9 +55395,10 @@ zend_leave_helper_SPEC_LABEL:
 
 	if (EG(current_execute_data)->func) {
 		zend_function *func = EG(current_execute_data)->func;
-		zend_instrument_cache *cache = ZEND_MAP_PTR_GET(func->common.instrument_cache);
-		if (cache != ZEND_NOT_INSTRUMENTED) {
-			zend_instrument_call_end_handlers(EG(current_execute_data), cache);
+		zend_instrument_fcall_cache *cache =
+			ZEND_MAP_PTR_GET(func->common.instrument_cache);
+		if (cache != ZEND_INSTRUMENT_FCALL_NOT_INSTRUMENTED) {
+			zend_instrument_fcall_call_end(cache, EG(current_execute_data), return_value);
 		}
 	}
 


### PR DESCRIPTION
This leaves room for other types of instruments in the future.

Also passes the return_value into the end handler, or an undef one in the case of an exception. We could pass NULL instead -- not sure what is better.